### PR TITLE
merge

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -1,6 +1,7 @@
 # BEGIN: lto
 # Packages which cannot be built with LTO at all
 app-admin/keepassxc *FLAGS-=-flto* # segfaults on start since Qt 5.15.1
+app-containers/runc *FLAGS-=-flto* # clash with	hardened flag, see Bug 935459
 app-emulation/dosemu *FLAGS-=-flto* # Issue #163
 app-emulation/libguestfs *FLAGS-=-flto*
 app-emulation/libpod *FLAGS-=-flto*

--- a/sys-config/ltoize/ltoize-0.10.0.ebuild
+++ b/sys-config/ltoize/ltoize-0.10.0.ebuild
@@ -1,0 +1,135 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="A configuration for portage to make building with LTO easy"
+HOMEPAGE="https://github.com/InBetweenNames/gentooLTO"
+
+#Note: there's nothing preventing this from working on stable, but the dependencies of ltoize aren't keyworded for
+#stable, so we only can do testing
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
+
+SRC_URI=""
+
+LICENSE="GPL-2+"
+SLOT="0"
+IUSE="clang keep-nocommon override-flagomatic"
+
+#portage-bashrc-mv can be obtained from mv overlay
+DEPEND="
+	app-portage/portage-bashrc-mv[cflags]
+	sys-apps/portage
+	sys-devel/gcc-config
+"
+RDEPEND="${DEPEND}"
+
+#Test binutils and gcc version
+pkg_setup() {
+
+	ACTIVE_GCC=$(gcc-fullversion)
+
+	if ver_test "${ACTIVE_GCC}" -lt 10.2.0; then
+		ewarn "Warning: Active GCC version '$ACTIVE_GCC' is lower then the expected version '10.2.0', it is recommended that you use the newest GCC if you want LTO."
+		if [ "${I_KNOW_WHAT_I_AM_DOING}" != "y" ]; then
+			eerror "Aborting LTOize installation due to older GCC version '$ACTIVE_GCC' -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
+			die
+		else
+			ewarn "I_KNOW_WHAT_I_AM_DOING=y -- continuing anyway"
+		fi
+	fi
+
+	if [ -f "${PORTAGE_CONFIGROOT%/}/etc/portage/package.cflags" ]; then
+		eerror "${PORTAGE_CONFIGROOT%/}/etc/portage/package.cflags is a file not a directory.  Please convert package.cflags to a directory with the current contents of package.cflags being moved to a file inside it."
+		die
+	fi
+
+}
+
+pkg_preinst() {
+	ACTIVE_GCC=$(gcc-fullversion)
+	if use override-flagomatic; then
+		if [ -z "${LTO_OVERLAY_PATH}" ]; then
+			eerror "It seems you're using the override-flagomatic feature of GentooLTO.  You must set LTO_OVERLAY_PATH in your make.conf to point to where lto-overlay lives."
+			eerror "You can use: 'portageq get_repo_path ${PORTAGE_CONFIGROOT} lto-overlay' to obtain it if you're not sure."
+			die
+		fi
+	fi
+
+	GENTOOLTO_PORTDIR="${LTO_OVERLAY_PATH}"
+	LTO_PORTAGE_DIR="${GENTOOLTO_PORTDIR}/${CATEGORY}/${PN}/files"
+
+	COMMON_WORKAROUNDS=(
+		cmake-makefile.conf
+		devirtualize-at-ltrans.conf
+		graphite.conf
+		ipa-pta.conf
+		lto.conf
+		no-common-libtool.conf
+		no-plt.conf
+		no-semantic-interposition.conf
+		optimizations.conf
+		portage-bashrc-mv.conf
+		tls-dialect.conf
+		use-ld.conf
+	)
+
+	#Install make.conf settings
+	elog "Installing make.conf.lto.defines definitions for optimizations used in this overlay"
+	dosym "${LTO_PORTAGE_DIR}/make.conf.lto.defines" "${PORTAGE_CONFIGROOT#${EPREFIX}}/etc/portage/make.conf.lto.defines"
+
+	elog "Installing make.conf.lto default full optimization config for make.conf"
+	dosym "${LTO_PORTAGE_DIR}/make.conf.lto" "${PORTAGE_CONFIGROOT#${EPREFIX}}/etc/portage/make.conf.lto"
+
+	#Install main workarounds files
+	for i in "${COMMON_WORKAROUNDS[@]}"; do
+		elog "Installing package.cflags ${i} override"
+		dosym "${LTO_PORTAGE_DIR}/package.cflags/${i}" "${PORTAGE_CONFIGROOT#${EPREFIX}}/etc/portage/package.cflags/${i}"
+	done
+
+	#Install -fno-common workarounds file
+	use keep-nocommon && dosym "${LTO_PORTAGE_DIR}/package.cflags/no-common.conf" \
+	"${PORTAGE_CONFIGROOT#${EPREFIX}%/}/etc/portage/package.cflags/no-common.conf"
+
+	# Install Clang LTO workarounds
+	use clang && dosym "${LTO_PORTAGE_DIR}/package.cflags/clang.conf" \
+	"${PORTAGE_CONFIGROOT#${EPREFIX}%/}/etc/portage/package.cflags/clang.conf"
+
+	#Install patch framework
+	elog "Installing bashrc.d hook symlink to apply LTO patches directly from lto-overlay"
+	dosym "${LTO_PORTAGE_DIR}/bashrc.d/41-lto-patch.sh" "${PORTAGE_CONFIGROOT#${EPREFIX}}/etc/portage/bashrc.d/41-lto-patch.sh"
+
+	#Optional: install flag-o-matic overrides
+	if use override-flagomatic; then
+		ewarn "Installing bashrc.d hook to override strip-flags and replace-flags functions in flag-o-matic.  This is an experimental feature!"
+		dosym "${LTO_PORTAGE_DIR}/bashrc.d/42-lto-flag-o-matic.sh" "${PORTAGE_CONFIGROOT#${EPREFIX}}/etc/portage/bashrc.d/42-lto-flag-o-matic.sh"
+		dosym "${LTO_PORTAGE_DIR}/package.cflags/flag-o-matic.conf" "${PORTAGE_CONFIGROOT#${EPREFIX}}/etc/portage/package.cflags/flag-o-matic.conf"
+	fi
+
+	elog "Installing bashrc.d hook symlink to override package libtool lt_cv_sys_global_symbol_pipe and lt_cv_sys_global_symbol_to_cdecl"
+	dosym "${LTO_PORTAGE_DIR}/bashrc.d/43-lto-no-common.sh" "${PORTAGE_CONFIGROOT#${EPREFIX}}/etc/portage/bashrc.d/43-lto-no-common.sh"
+}
+
+pkg_postinst()
+{
+	elog "If you have not done so, you will need to modify your make.conf settings to enable LTO building on your system."
+	elog "A symlink has been placed in ${PORTAGE_CONFIGROOT%/}/etc/portage/make.conf.lto that can be used as a basis for these modifications."
+	elog "See README.md for more details."
+	elog "lto-overlay and ltoize are part of a project to help find undefined behaviour in C and C++ programs through the use of aggressive compiler optimizations."
+	elog "One of the aims of this project is also to improve the performance of linux distributions through these mechanisms as well."
+	elog "Occasionally, you will experience breakage due to LTO problems.  These are documented in the README.md of this repository."
+	elog "If you add an override for a particular package, please consider sending a pull request upstream so that other users of this repository can benefit."
+	ewarn "You will require a complete system rebuild in order to gain the benefits of LTO system-wide."
+	echo
+	elog "Please consider reading the README.md at the root of this repository before attempting to rebuild your system to familiarize yourself with the goals of this project and potential pitfalls you could run into."
+	echo
+	ewarn "This is an experimental project and should not be used on a stable system in its current state."
+
+	BINUTILS_VER=$(binutils-config ${CHOST} -c | sed -e "s/.*-//")
+
+	if ver_test "${BINUTILS_VER}" -lt 2.34; then
+		ewarn "Warning: active binutils version < 2.34, it is recommended that you use the newest binutils for LTO."
+	fi
+}


### PR DESCRIPTION
Title: <category>/<package>: <description>

Ensure that any added workarounds have a comment explaining the compilation error which requires it.
Any removed workarounds should be moved to the fixed section.
If an issue exists, please link it.
See .github/CONTRIBUTING.md for more information.

## Summary by Sourcery

Add ltoize package and configuration files to enable LTO builds.  Introduce a workaround for app-containers/runc to address build issues with hardened flags.  Set up various hooks and overrides to manage LTO settings and workarounds within portage.

Build:
- Add workaround for app-containers/runc to disable LTO when hardened flags are used, fixing a clash that prevented building.

Chores:
- Add initial ltoize ebuild and supporting files to automate LTO configuration in portage.
- Install make.conf settings for LTO optimizations.
- Install main workaround files for package.cflags.
- Install bashrc.d hooks for applying LTO patches and overriding flag-o-matic functions (optional).
- Install bashrc.d hook to override libtool cache variables related to -fno-common.
- Display post-install messages with instructions and warnings about LTO usage and potential issues.
- Check binutils version and warn if it's older than recommended for LTO.